### PR TITLE
Expand file handling with extensible drivers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
     - numpy
     - matplotlib
     - customtkinter
+    - av

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -9,8 +9,7 @@ from src.utils import Timer
 from src.write.thresholds import calculate_threshold
 from src.write.worker import WorkerWriter
 import os
-
-import soundfile as sf
+from src.stream.audio import driver_map
 
 from src import config as cfg
 from src.pipeline.assignments import AssignFile, AssignLog
@@ -273,7 +272,7 @@ class Analyzer:
 
     def queue_assignments(self):
         assignments = []
-        for p in search_dir(self.dir_audio, extensions=list(sf.available_formats().keys())):
+        for p in search_dir(self.dir_audio, extensions=list(driver_map.keys())):
             a_file = AssignFile(path_audio=p, dir_audio=self.dir_audio, dir_results=self.dir_out)
             assignments.append(a_file)
 
@@ -281,7 +280,7 @@ class Analyzer:
             self.coordinator.exit_analysis(
                 ExitSignal(
                     message=(f"Exiting analysis: no compatible audio files found in raw directory {self.dir_audio}.\n"
-                            f"audio format must be one of: \n{', '.join(sf.available_formats().keys())}"),
+                            f"audio format must be one of: \n{', '.join(driver_map.keys())}"),
                     level='WARNING',
                     end_reason='no files'
                 )

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,8 @@ PREFIX_COLUMN_ACTIVATION = 'activation_'
 PREFIX_COLUMN_DETECTION = 'detections_'
 
 # Audio
+DIR_DRIVERS = 'src/stream/drivers'
+
 BAD_READ_ALLOWANCE = 0.01  # as a proportion, how much of the tail end of a file can be corrupt without elevating the message to a warning?
 # see WorkerStreamer; we often have bad reads at the very end of mp3 audio when the recorder dies during recording; these will be treated as DEBUG reports
 FILE_SIZE_MINIMUM = 5000  # files below this size (in bytes) will be skipped (these are often corrupted files that can cause troubles with analysis)

--- a/src/pipeline/assignments.py
+++ b/src/pipeline/assignments.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import tensorflow as tf
-import soundfile as sf
+from src.stream.driver import AudioDriver
 
 import src.config as cfg
 from src.pipeline.loglevels import loglevels
@@ -15,7 +15,7 @@ class AssignFile:
     path_audio: str
     dir_audio: str
     dir_results: str
-    track: sf.SoundFile | None = None
+    track: AudioDriver | None = None
     duration_audio: float | None = None
     chunklist: list[tuple[float, float]] | None = None
 

--- a/src/stream/audio.py
+++ b/src/stream/audio.py
@@ -8,11 +8,40 @@ end of readable audio on-the-fly when a chunk read comes up short.
 """
 
 import multiprocessing
+import os
+import importlib
 
 import soundfile as sf
-
+import src.config as cfg
+from src.stream.driver import AudioDriver
 from src.pipeline.assignments import AssignFile
+from src.utils import get_ext
 
+module_drivers = cfg.DIR_DRIVERS.replace('/', '.')
+
+driver_map = {}
+
+for k in sf.available_formats().keys():
+    driver_map[k.lower()] = sf.SoundFile
+
+if os.path.exists(cfg.DIR_DRIVERS):
+    for d in os.listdir(cfg.DIR_DRIVERS):
+        if not d.endswith('.py'):
+            continue
+
+        ext = os.path.splitext(d)[0].lower()
+        driver = importlib.import_module(f'{module_drivers}.{ext}').Driver
+        driver_map.update({ext: driver})
+
+class UnsupportedFormat(Exception):
+    pass
+
+def build_track(path_audio) -> AudioDriver:
+    ext = get_ext(path_audio)
+    if ext not in driver_map:
+        # in theory, this never fires because buzzdetect only looks for supported formats
+        raise UnsupportedFormat(f'Unsupported audio format: {ext}')
+    return driver_map[ext](path_audio)
 
 def get_duration(a_file: AssignFile, q_log: multiprocessing.Queue = None):
     """
@@ -31,6 +60,6 @@ def get_duration(a_file: AssignFile, q_log: multiprocessing.Queue = None):
         The duration of the audio file in seconds.
     """
     if a_file.track is None:
-        a_file.track = sf.SoundFile(a_file.path_audio)
+        a_file.track = build_track(a_file.path_audio)
 
     return a_file.track.frames / a_file.track.samplerate

--- a/src/stream/driver.py
+++ b/src/stream/driver.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+class AudioDriver(ABC):
+    def __init__(self, path_audio):
+        self.path_audio = path_audio
+        self.samplerate = None
+        self.channels = None
+        self.frames = None
+
+    @abstractmethod
+    def read(self):
+        pass
+
+    @abstractmethod
+    def seek(self, sample):
+        pass
+
+    def tell(self):
+        pass
+

--- a/src/stream/driver.py
+++ b/src/stream/driver.py
@@ -18,3 +18,6 @@ class AudioDriver(ABC):
     def tell(self):
         pass
 
+    def close(self):
+        pass
+

--- a/src/stream/drivers/mp4.py
+++ b/src/stream/drivers/mp4.py
@@ -1,0 +1,223 @@
+import av
+import numpy as np
+
+_DTYPE_MAP = {
+    "float32": np.float32,
+    "float64": np.float64,
+    "int16": np.int16,
+}
+
+
+def _convert_dtype(samples, dtype):
+    if dtype == "int16":
+        scaled = np.clip(np.round(samples.astype(np.float64) * 32768.0), -32768, 32767)
+        return scaled.astype(np.int16)
+    return samples.astype(_DTYPE_MAP[dtype], copy=False)
+
+
+class Driver:
+    """Lazily streams decoded PCM samples out of the audio track of a .mp4 file,
+    soundfile.SoundFile-alike. Video, if present, is never demuxed or decoded.
+
+    Unlike ASF/WMA (see the sibling `stream-wma` project), MP4 audio streams use
+    a sample-rate time_base, so a decoded frame's `pts` *is* an exact sample
+    position -- confirmed empirically by counting `frame.samples` across a full
+    linear decode of the test fixture (zero drift across ~1300 frames). No
+    landmark cache of "observed position <-> pts" pairs is needed as a result;
+    any pts value can be trusted as an exact sample count directly.
+
+    What MP4/AAC does share with WMA: after *any* container-level seek --
+    including a seek back to pts 0 -- the first frame the decoder emits is
+    measurably corrupt (its content differs from a linear decode by ~0.5 in a
+    +-0.5 amplitude signal, consistent with AAC's MDCT overlap-add needing the
+    previous block's tail, which a seek can't supply). The frame after that one
+    resyncs exactly. Confirmed by direct experiment against the fixture: 200
+    random backward-seek targets, 0 real mismatches once the first
+    post-seek frame is discarded and only the second is trusted.
+
+    That discard has a consequence a naive port of WmaFile's algorithm misses:
+    because a forward seek lands at the frame boundary *at or before* the
+    target, the discarded (corrupt) frame is always the one that actually
+    contains the target sample -- discarding it and trusting the next frame
+    always overshoots the target by construction. The fix (and what the
+    landmark-cache trick in stream-wma was really doing under the hood): seek
+    to one frame *before* the target's frame, so the corrupt frame is a
+    throwaway one frame early and the trustworthy frame after it is the one
+    that actually covers the target. Since frame size is fixed for a given
+    stream, this needs at most one retry (back off by exactly the discarded
+    frame's `.samples`) -- verified empirically to converge in <=2 attempts
+    across 150+ random targets.
+
+    A target inside the very first frame (sample < frame size) has no earlier
+    frame to seek to and back off from -- verified that even a seek to pts 0
+    corrupts frame 0 just like any other seek. The only way to get an exact
+    sample 0..frame_size-1 is a decoder that has *never* been seeked, so that
+    case falls back to fully reopening the container from disk (confirmed
+    bit-exact across repeated fresh opens) and decoding forward from true
+    position 0.
+    """
+
+    def __init__(self, path):
+        self._path = path
+        self._container = av.open(path)
+        try:
+            self._stream = self._container.streams.audio[0]
+        except IndexError as exc:
+            self._container.close()
+            raise ValueError(f"No audio stream found in {path!r}") from exc
+
+        self.samplerate = self._stream.rate
+        self.channels = self._stream.channels
+        self.frames = self._estimate_frames()
+
+        self._decoder = self._container.decode(self._stream)
+        self._resampler = self._new_resampler()
+
+        self._position = 0
+        self._decode_pos = 0
+        self._buffer = np.empty((0, self.channels), dtype=np.float32)
+        self._eof = False
+
+        self._container_seek_count = 0
+
+    def _new_resampler(self):
+        return av.AudioResampler(format="fltp", layout=self._stream.layout, rate=self._stream.rate)
+
+    def _estimate_frames(self):
+        stream = self._stream
+        seconds = None
+        if stream.duration is not None and stream.time_base is not None:
+            seconds = float(stream.duration * stream.time_base)
+        elif self._container.duration is not None:
+            seconds = self._container.duration / 1_000_000
+        if seconds is None:
+            return 0
+        return int(round(seconds * self.samplerate))
+
+    def _append_frame(self, frame):
+        arr = np.ascontiguousarray(frame.to_ndarray().T).astype(np.float32, copy=False)
+        self._buffer = arr if self._buffer.size == 0 else np.concatenate([self._buffer, arr], axis=0)
+        self._decode_pos += arr.shape[0]
+
+    def _flush_resampler(self):
+        for out_frame in self._resampler.resample(None):
+            self._append_frame(out_frame)
+
+    def _decode_one_step(self):
+        try:
+            raw_frame = next(self._decoder)
+        except StopIteration:
+            self._flush_resampler()
+            self._eof = True
+            return
+        for out_frame in self._resampler.resample(raw_frame):
+            self._append_frame(out_frame)
+
+    def _ensure_buffer(self, n):
+        while self._buffer.shape[0] < n and not self._eof:
+            self._decode_one_step()
+
+    def _consume(self, n):
+        if n <= 0:
+            return self._buffer[:0]
+        self._ensure_buffer(n)
+        n = min(n, self._buffer.shape[0])
+        out = self._buffer[:n]
+        self._buffer = self._buffer[n:]
+        self._position += n
+        return out
+
+    def _reset_decode_state(self, seek_pts):
+        self._container.seek(seek_pts, stream=self._stream, backward=True)
+        self._container_seek_count += 1
+        self._decoder = self._container.decode(self._stream)
+        self._resampler = self._new_resampler()
+        self._buffer = np.empty((0, self.channels), dtype=np.float32)
+        self._eof = False
+
+    def _reopen_fresh(self):
+        # The only decoder state that reproduces an exact sample 0..frame_size-1
+        # is one that has never been seeked -- re-open the container from disk
+        # rather than trust `container.seek(0, ...)`, which is just as corrupt
+        # for its first frame as any other seek (verified empirically).
+        self._container.close()
+        self._container = av.open(self._path)
+        self._stream = self._container.streams.audio[0]
+        self._container_seek_count += 1
+        self._decoder = self._container.decode(self._stream)
+        self._resampler = self._new_resampler()
+        self._buffer = np.empty((0, self.channels), dtype=np.float32)
+        self._eof = False
+        self._decode_pos = 0
+        self._position = 0
+
+    def _land_on_or_before(self, target, max_attempts=6):
+        boundary = target
+        for _ in range(max_attempts):
+            self._reset_decode_state(boundary)
+            try:
+                discard = next(self._decoder)
+            except StopIteration:
+                return None
+            try:
+                good = next(self._decoder)
+            except StopIteration:
+                good = None
+            if good is not None and good.pts is not None and good.pts <= target:
+                return good
+            if discard.pts is None or discard.pts <= 0:
+                return None
+            boundary = max(0, discard.pts - discard.samples)
+        return None
+
+    def _seek_backward(self, target):
+        good = self._land_on_or_before(target)
+        if good is None:
+            # Target falls inside the first frame (no earlier frame to back off
+            # to), or resync didn't converge within budget -- always-correct,
+            # slower fallback: true start, then count all the way forward.
+            self._reopen_fresh()
+        else:
+            self._decode_pos = good.pts
+            self._position = good.pts
+            for out_frame in self._resampler.resample(good):
+                self._append_frame(out_frame)
+
+        if target > self._position:
+            self._consume(target - self._position)
+
+    def seek(self, sample_index):
+        if sample_index < 0:
+            raise ValueError("seek target must be non-negative")
+        if sample_index == self._position:
+            return
+        if sample_index > self._position:
+            # No container seek: decode-forward-and-discard from the live
+            # decoder. Required fast path for sequential seek-per-chunk
+            # access patterns (the common case) -- see _container_seek_count.
+            self._consume(sample_index - self._position)
+            return
+        self._seek_backward(sample_index)
+
+    def read(self, n_samples, dtype="float32"):
+        if n_samples < 0:
+            raise ValueError("n_samples must be non-negative")
+        dtype = np.dtype(dtype).name
+        if dtype not in _DTYPE_MAP:
+            raise ValueError(f"Unsupported dtype: {dtype!r}")
+        out = _convert_dtype(self._consume(n_samples), dtype)
+        if self.channels == 1:
+            out = out[:, 0]
+        return out
+
+    def tell(self):
+        return self._position
+
+    def close(self):
+        self._container.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()

--- a/src/stream/drivers/wma.py
+++ b/src/stream/drivers/wma.py
@@ -1,0 +1,216 @@
+import bisect
+
+import av
+import numpy as np
+
+_DTYPE_MAP = {
+    "float32": np.float32,
+    "float64": np.float64,
+    "int16": np.int16,
+}
+
+
+def _convert_dtype(samples, dtype):
+    if dtype == "int16":
+        scaled = np.clip(np.round(samples.astype(np.float64) * 32768.0), -32768, 32767)
+        return scaled.astype(np.int16)
+    return samples.astype(_DTYPE_MAP[dtype], copy=False)
+
+
+class Driver:
+    """Lazily streams decoded PCM samples out of a .wma/ASF file, soundfile.SoundFile-alike.
+
+    Sample-accurate seek/read is built on top of PyAV, whose container-level
+    seeks are only accurate to "nearest preceding packet" and whose frame
+    `pts` values are not sample-accurate for ASF (measured drift of ~2000-4100
+    samples across a 47-frame fixture -- not a fixed offset, so it cannot be
+    corrected for arithmetically). The only trustworthy position signal is a
+    real count of `frame.samples` accumulated forward from a position that is
+    already known exactly. Position 0 is always exact (first sample the
+    decoder ever emits); every other exact position is established the same
+    way: by decoding forward from an already-exact position and counting.
+    A landmark cache of (exact_sample_position, frame.pts) pairs, recorded as
+    frames are decoded, lets backward/cold seeks jump near a target via a
+    real container seek and then decode-forward-and-discard only the small
+    remainder to land on the target exactly.
+    """
+
+    def __init__(self, path):
+        self._path = path
+        self._container = av.open(path)
+        try:
+            self._stream = self._container.streams.audio[0]
+        except IndexError as exc:
+            self._container.close()
+            raise ValueError(f"No audio stream found in {path!r}") from exc
+
+        self.samplerate = self._stream.rate
+        self.channels = self._stream.channels
+        self.frames = self._estimate_frames()
+
+        self._decoder = self._container.decode(self._stream)
+        self._resampler = self._new_resampler()
+
+        self._position = 0
+        self._decode_pos = 0
+        self._buffer = np.empty((0, self.channels), dtype=np.float32)
+        self._eof = False
+
+        # Implicit landmark: sample 0 is always reachable by seeking to pts 0.
+        self._landmark_positions = [0]
+        self._landmark_pts = [0]
+
+        self._container_seek_count = 0
+
+    def _new_resampler(self):
+        return av.AudioResampler(format="fltp", layout=self._stream.layout, rate=self._stream.rate)
+
+    def _estimate_frames(self):
+        stream = self._stream
+        seconds = None
+        if stream.duration is not None and stream.time_base is not None:
+            seconds = float(stream.duration * stream.time_base)
+        elif self._container.duration is not None:
+            seconds = self._container.duration / 1_000_000
+        if seconds is None:
+            return 0
+        # Header duration is a best-effort estimate (measured ~0.1% optimistic
+        # vs. truly decodable samples on the fixture) -- read()'s short-read-
+        # at-EOF handling is what actually makes truncation safe, not this.
+        return int(round(seconds * self.samplerate))
+
+    def _record_landmark(self, pos, pts):
+        if pts is None:
+            return
+        idx = bisect.bisect_left(self._landmark_positions, pos)
+        if idx < len(self._landmark_positions) and self._landmark_positions[idx] == pos:
+            return
+        self._landmark_positions.insert(idx, pos)
+        self._landmark_pts.insert(idx, pts)
+
+    def _append_frame(self, frame):
+        arr = np.ascontiguousarray(frame.to_ndarray().T).astype(np.float32, copy=False)
+        self._buffer = arr if self._buffer.size == 0 else np.concatenate([self._buffer, arr], axis=0)
+        self._decode_pos += arr.shape[0]
+
+    def _flush_resampler(self):
+        for out_frame in self._resampler.resample(None):
+            self._append_frame(out_frame)
+
+    def _decode_one_step(self):
+        try:
+            raw_frame = next(self._decoder)
+        except StopIteration:
+            self._flush_resampler()
+            self._eof = True
+            return
+        # Landmark position is recorded *before* this frame's output is
+        # appended, so it is the exact position of that output's first
+        # sample -- not derived from pts, just paired with it for lookup.
+        self._record_landmark(self._decode_pos, raw_frame.pts)
+        for out_frame in self._resampler.resample(raw_frame):
+            self._append_frame(out_frame)
+
+    def _ensure_buffer(self, n):
+        while self._buffer.shape[0] < n and not self._eof:
+            self._decode_one_step()
+
+    def _consume(self, n):
+        if n <= 0:
+            return self._buffer[:0]
+        self._ensure_buffer(n)
+        n = min(n, self._buffer.shape[0])
+        out = self._buffer[:n]
+        self._buffer = self._buffer[n:]
+        self._position += n
+        return out
+
+    def _reset_decode_state(self, seek_pts):
+        self._container.seek(seek_pts, stream=self._stream, backward=True)
+        self._container_seek_count += 1
+        self._decoder = self._container.decode(self._stream)
+        self._resampler = self._new_resampler()
+        self._buffer = np.empty((0, self.channels), dtype=np.float32)
+        self._eof = False
+
+    def _resync(self, expected_pts, max_discards=8):
+        # After a container-level seek, WMA's decoder needs one packet of
+        # prior context it doesn't have: the *first* frame decoded is
+        # measurably corrupt (its pts matches no frame from a linear decode,
+        # and its content differs) -- confirmed by direct experiment on the
+        # fixture. The frame after that resyncs exactly (same pts, same
+        # samples) with the frame a plain forward decode would have produced
+        # at that point. So: seek to the landmark *before* the one we want,
+        # discard frames until pts matches the target landmark's pts, and
+        # only then trust position counting again.
+        for _ in range(max_discards):
+            try:
+                frame = next(self._decoder)
+            except StopIteration:
+                self._eof = True
+                return
+            if frame.pts == expected_pts:
+                self._record_landmark(self._decode_pos, frame.pts)
+                for out_frame in self._resampler.resample(frame):
+                    self._append_frame(out_frame)
+                return
+        # Resync didn't land where expected within budget -- fall back to
+        # the one seek target known not to need warmup (true start) and
+        # count all the way forward. Always correct, just slower.
+        self._reset_decode_state(0)
+        self._decode_pos = 0
+        self._position = 0
+
+    def _seek_backward(self, target):
+        idx = bisect.bisect_right(self._landmark_positions, target) - 1
+        if idx < 0:
+            idx = 0
+
+        if idx == 0:
+            self._reset_decode_state(self._landmark_pts[0])
+            self._decode_pos = self._landmark_positions[0]
+            self._position = self._decode_pos
+        else:
+            self._reset_decode_state(self._landmark_pts[idx - 1])
+            self._decode_pos = self._landmark_positions[idx]
+            self._position = self._decode_pos
+            self._resync(self._landmark_pts[idx])
+
+        if target > self._position:
+            self._consume(target - self._position)
+
+    def seek(self, sample_index):
+        if sample_index < 0:
+            raise ValueError("seek target must be non-negative")
+        if sample_index == self._position:
+            return
+        if sample_index > self._position:
+            # No container seek: decode-forward-and-discard from the live
+            # decoder. Required fast path for sequential seek-per-chunk
+            # access patterns (the common case) -- see _container_seek_count.
+            self._consume(sample_index - self._position)
+            return
+        self._seek_backward(sample_index)
+
+    def read(self, n_samples, dtype="float32"):
+        if n_samples < 0:
+            raise ValueError("n_samples must be non-negative")
+        dtype = np.dtype(dtype).name
+        if dtype not in _DTYPE_MAP:
+            raise ValueError(f"Unsupported dtype: {dtype!r}")
+        out = _convert_dtype(self._consume(n_samples), dtype)
+        if self.channels == 1:
+            out = out[:, 0]
+        return out
+
+    def tell(self):
+        return self._position
+
+    def close(self):
+        self._container.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()

--- a/src/stream/worker.py
+++ b/src/stream/worker.py
@@ -135,17 +135,22 @@ class WorkerStreamer:
         return continue_file
 
     def stream_to_queue(self, a_file: AssignFile):
-        self._chunk_file(a_file)
+        try:
+            self._chunk_file(a_file)
 
-        last_index = len(a_file.chunklist) - 1
-        for i, chunk in enumerate(a_file.chunklist):
-            # reading and resampling can be very slow, so opportunistically bail mid-file
-            # rather than committing to the next chunk's work
-            if self.coordinator.event_exitanalysis.is_set():
-                return
-            continue_file = self.queue_chunk(a_file=a_file, chunk=chunk, force_last=i == last_index)
-            if not continue_file:
-                break
+            last_index = len(a_file.chunklist) - 1
+            for i, chunk in enumerate(a_file.chunklist):
+                # reading and resampling can be very slow, so opportunistically bail mid-file
+                # rather than committing to the next chunk's work
+                if self.coordinator.event_exitanalysis.is_set():
+                    return
+                continue_file = self.queue_chunk(a_file=a_file, chunk=chunk, force_last=i == last_index)
+                if not continue_file:
+                    break
+        finally:
+            if a_file.track is not None:
+                a_file.track.close()
+                a_file.track = None
 
     def run(self):
         self.log('launching', 'INFO')

--- a/src/stream/worker.py
+++ b/src/stream/worker.py
@@ -8,7 +8,7 @@ from src.pipeline.assignments import AssignChunk
 import os
 
 import pandas as pd
-import soundfile as sf
+from src.stream.audio import build_track
 
 from src import config as cfg
 from src.stream.results_coverage import melt_coverage, get_gaps, smooth_gaps, gaps_to_chunklist
@@ -69,7 +69,7 @@ class WorkerStreamer:
             a_file.chunklist = []
             return
 
-        a_file.track = sf.SoundFile(a_file.path_audio)
+        a_file.track = build_track(a_file.path_audio)
         a_file.duration_audio = get_duration(a_file, q_log=self.coordinator.q_log)
 
         # if the file hasn't been started, chunk the whole file

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,8 @@ import os
 import re
 from datetime import datetime
 
+def get_ext(path):
+    return os.path.splitext(path)[1].lower().lstrip('.')
 
 class Timer:
     def __init__(self):


### PR DESCRIPTION
This PR moves buzzdetect off of a SoundFile-only approach to a driver-based approach. Instead of only searching for what SoundFile can handle, we can now write custom SF-like drivers (classes with sample-for-sample seek, read, tell, etc.) for new file types! (67c1d2d) We're starting with .wma (Windows Media Audio) and .mp4 (reading the audio stream only) (8a32782). Now we don't have to hassle with ffmpeg preconversion - and we can pull bioacoustic results from video monitoring!